### PR TITLE
Issue #10 - Update Chai Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "underscore": "1.6.0"
   },
   "peerDependencies": {
-    "chai": ">= 1.6.1 < 2"
+    "chai": ">= 1.6.1 < 4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bit-mask": "0.0.2-alpha"
   },
   "devDependencies": {
-    "chai": "^1.9.1",
+    "chai": "^3.5.0",
     "chai-json-schema": "1.0.4",
     "grunt": "0.4.1",
     "grunt-bump": "0.0.11",


### PR DESCRIPTION
I'm not sure whether or not the pre-existing tests actually are sufficient for verifying this, but all tests pass when the `devDependency` for chai is updated to 3.5.0.